### PR TITLE
Extra ";" Prevents Compilation with"-Wpedantic"

### DIFF
--- a/vmmlib/aabb.hpp
+++ b/vmmlib/aabb.hpp
@@ -380,6 +380,6 @@ AABB< T > AABB< T >::makeUnitBox()
     return AABB( Vector< 3, T >::ZERO, Vector< 3, T >::ONE );
 }
 
-}; //namespace vmml
+} //namespace vmml
 
 #endif


### PR DESCRIPTION
vmmlib/aabb.hpp:374:2: error: extra ‘;’ [-Wpedantic]